### PR TITLE
Use Angular's dev server proxy support instead of manually changing urls

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -57,7 +57,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "lu-explorer:build"
+            "browserTarget": "lu-explorer:build",
+            "proxyConfig": "src/proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/src/app/activities/activity-detail/activity-detail.component.html
+++ b/src/app/activities/activity-detail/activity-detail.component.html
@@ -3,7 +3,7 @@
   <li>{{activity_id}}</li>
 </div>
 
-<img *ngIf="activity && activity.leaderboardType == 1" class="header" [src]="'ui/ingame/instancelobby_i68.png' | res"
+<img *ngIf="activity && activity.leaderboardType == 1" class="header" src="/lu-res/ui/ingame/instancelobby_i68.png"
   title="This activity is (likely) a race" />
 
 <h2>Activity #{{activity_id}} <small *ngIf="activity_loc">"{{activity_loc.ActivityName}}"</small></h2>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -42,8 +42,8 @@
 
 <h2>Answer the Call &mdash; Save Imagination!</h2>
 <p class="faction-banners">
-  <img [src]="'/ui/ingame/factionmission_i2e.png' | res" />
-  <img [src]="'/ui/ingame/factionmission_i4c.png' | res" />
-  <img [src]="'/ui/ingame/factionmission_i32.png' | res" />
-  <img [src]="'/ui/ingame/factionmission_i27.png' | res" />
+  <img src="/lu-res/ui/ingame/factionmission_i2e.png" />
+  <img src="/lu-res/ui/ingame/factionmission_i4c.png" />
+  <img src="/lu-res//ui/ingame/factionmission_i32.png" />
+  <img src="/lu-res/ui/ingame/factionmission_i27.png" />
 </p>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -44,6 +44,6 @@
 <p class="faction-banners">
   <img src="/lu-res/ui/ingame/factionmission_i2e.png" />
   <img src="/lu-res/ui/ingame/factionmission_i4c.png" />
-  <img src="/lu-res//ui/ingame/factionmission_i32.png" />
+  <img src="/lu-res/ui/ingame/factionmission_i32.png" />
   <img src="/lu-res/ui/ingame/factionmission_i27.png" />
 </p>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,6 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { environment } from '../../environments/environment';
-import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-dashboard',
@@ -9,14 +7,10 @@ import { HttpClient } from '@angular/common/http';
 })
 export class DashboardComponent implements OnInit {
 
-  baseUrl: string;
-
-  constructor(private http: HttpClient) {
-    this.baseUrl = environment.data.baseUrl;
+  constructor() {
   }
 
   ngOnInit() {
-    this.http.get('/lu-json/index.json').subscribe(x => console.log(x));
   }
 
 }

--- a/src/app/gui/item-rarity/item-rarity.component.ts
+++ b/src/app/gui/item-rarity/item-rarity.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { LuResService } from '../../services';
 
 @Component({
   selector: 'lux-item-rarity',
@@ -11,11 +10,11 @@ export class ItemRarityComponent implements OnInit {
   private onImg: string;
   private offImg: string;
 
-  constructor(private luRes: LuResService) { }
+  constructor() { }
 
   ngOnInit(): void {
-    this.onImg = this.luRes.getResolvedResUrl('ui/ingame/itemrollover_i8e.png');
-    this.offImg = this.luRes.getResolvedResUrl('ui/ingame/itemrollover_i8f.png');
+    this.onImg = "/lu-res/ui/ingame/itemrollover_i8e.png";
+    this.offImg = "/lu-res/ui/ingame/itemrollover_i8f.png";
   }
 
   img(val: number) {

--- a/src/app/gui/item-value/item-value.component.html
+++ b/src/app/gui/item-value/item-value.component.html
@@ -1,4 +1,4 @@
 <div class="value">
-    <img [src]="coinImage" />
+    <img src="/lu-res/ui/ingame/itemrollover_i64.png" />
     {{value}}
 </div>

--- a/src/app/gui/item-value/item-value.component.ts
+++ b/src/app/gui/item-value/item-value.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { LuResService } from '../../services';
 
 @Component({
   selector: 'lux-item-value',
@@ -8,12 +7,10 @@ import { LuResService } from '../../services';
 })
 export class ItemValueComponent implements OnInit {
   @Input() value: number;
-  coinImage: string;
 
-  constructor(private luRes: LuResService) { }
+  constructor() { }
 
   ngOnInit(): void {
-    this.coinImage = this.luRes.getResolvedResUrl('ui/ingame/itemrollover_i64.png');
   }
 
 }

--- a/src/app/gui/simple-flag/simple-flag.component.ts
+++ b/src/app/gui/simple-flag/simple-flag.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { LuResService } from '../../services';
 
 @Component({
   selector: 'lux-simple-flag',
@@ -14,11 +13,11 @@ export class SimpleFlagComponent implements OnInit {
   private trueImg: string;
   private falseImg: string;
 
-  constructor(private luRes: LuResService) { }
+  constructor() { }
 
   ngOnInit(): void {
-    this.trueImg = this.luRes.getResolvedResUrl('ui/ingame/propertymanagement_i7.png');
-    this.falseImg = this.luRes.getResolvedResUrl('ui/ingame/propertymanagement_i20.png');
+    this.trueImg = "/lu-res/ui/ingame/propertymanagement_i7.png";
+    this.falseImg = "/lu-res/ui/ingame/propertymanagement_i20.png";
   }
 
   valueImg() {

--- a/src/app/objects/components/destructible-component/destructible-component.component.html
+++ b/src/app/objects/components/destructible-component/destructible-component.component.html
@@ -6,15 +6,15 @@
       <span class="level">{{destructible.level}}</span>
     </div>
     <div *ngIf="destructible.life" class="buff-icon">
-      <img [src]="'textures/ui/inventory/common/heart.png' | res" title="Life" />
+      <img src="/lu-res/textures/ui/inventory/common/heart.png" title="Life" />
       <span> {{destructible.life}}</span>
     </div>
     <div *ngIf="destructible.imagination" class="buff-icon">
-      <img [src]="'textures/ui/inventory/common/imagination.png' | res" title="Imagination" />
+      <img src="/lu-res/textures/ui/inventory/common/imagination.png" title="Imagination" />
       <span> {{destructible.imagination}}</span>
     </div>
     <div *ngIf="destructible.armor" class="buff-icon">
-      <img [src]="'textures/ui/inventory/common/armor.png' | res" title="Armor" />
+      <img src="/lu-res/textures/ui/inventory/common/armor.png" title="Armor" />
       <span> {{destructible.armor}}</span>
     </div>
   </section>

--- a/src/app/objects/components/render-component/render-component.component.ts
+++ b/src/app/objects/components/render-component/render-component.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { LuJsonService, LuResService } from '../../../services';
+import { LuJsonService } from '../../../services';
 import { Observable, ReplaySubject } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { DB_mapShaders, DB_RenderComponent } from '../../../cdclient';

--- a/src/app/objects/components/render-component/render-component.component.ts
+++ b/src/app/objects/components/render-component/render-component.component.ts
@@ -14,7 +14,6 @@ export class RenderComponentComponent {
 
   $shaders: Observable<DB_mapShaders[]>;
   component: Observable<DB_RenderComponent>;
-  baseUrl: string;
   _ref: ReplaySubject<number>;
   _id: number;
 

--- a/src/app/objects/components/skill-component/skill-component.component.html
+++ b/src/app/objects/components/skill-component/skill-component.component.html
@@ -27,14 +27,14 @@
         </td>
         <td class="skill-buffs">
           <div *ngIf="entry.value.skill.lifeBonusUI" class="buff-icon">
-            <img [src]="'textures/ui/inventory/common/heart.png' | res"/>
+            <img src="/lu-res/textures/ui/inventory/common/heart.png"/>
             <span> +{{entry.value.skill.lifeBonusUI}}</span>
           </div>
           <div *ngIf="entry.value.skill.imBonusUI" class="buff-icon">
-            <img [src]="'textures/ui/inventory/common/imagination.png' | res" />
+            <img src="/lu-res/textures/ui/inventory/common/imagination.png" />
             <span> +{{entry.value.skill.imBonusUI}}</span></div>
           <div *ngIf="entry.value.skill.armorBonusUI" class="buff-icon">
-            <img [src]="'textures/ui/inventory/common/armor.png' | res" />
+            <img src="/lu-res/textures/ui/inventory/common/armor.png" />
             <span> +{{entry.value.skill.armorBonusUI}}</span></div>
         </td>
         <td>

--- a/src/app/objects/components/skill-component/skill-component.component.ts
+++ b/src/app/objects/components/skill-component/skill-component.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { ReplaySubject, from } from 'rxjs';
 import { map, combineAll, switchMap } from 'rxjs/operators';
 
-import { LuJsonService, LuResService } from '../../../services';
+import { LuJsonService } from '../../../services';
 import { SkillRef } from '../../../cdclient';
 
 @Component({
@@ -17,8 +17,7 @@ export class SkillComponentComponent implements OnInit {
   skill_ref: ReplaySubject<SkillRef[]>;
 
   constructor(
-    private luJsonService: LuJsonService,
-    private luResService: LuResService) {
+    private luJsonService: LuJsonService) {
 
     this.skill_ref = new ReplaySubject<SkillRef[]>(1);
     this.skills = this.skill_ref
@@ -59,12 +58,8 @@ export class SkillComponentComponent implements OnInit {
 
   ngOnInit() { }
 
-  image(path: string): string {
-    return this.luResService.getResolvedResUrl(path);
-  }
-
   bgImage(path: string): string {
-    return "url(" + this.image(path) + ")";
+    return "url(/lu-res/" + path + ")";
   }
 
 }

--- a/src/app/objects/detail/detail.component.html
+++ b/src/app/objects/detail/detail.component.html
@@ -7,7 +7,7 @@
   </ul>
 
   <img *ngIf="object.HQ_valid" class="pull-right img-tag"
-    [src]="'textures/ui/missions/faction_logos/nexus-force.png' | res" alt="This object is valid for NexusHQ"
+    src="/lu-res/textures/ui/missions/faction_logos/nexus-force.png" alt="This object is valid for NexusHQ"
     title="This object is valid for NexusHQ">
   <h2>{{object.name | uppercase }} <small *ngIf="objectLocale">"{{objectLocale.name}}"</small></h2>
 

--- a/src/app/objects/npc-icon/npc-icon.component.html
+++ b/src/app/objects/npc-icon/npc-icon.component.html
@@ -1,3 +1,3 @@
 <ng-container *ngIf="icon && icon.Texture">
-  <img [style.max-width]="width" src="{{baseUrl}}/lu-res/{{ (icon.Texture | lowercase) | replace:'dds$':'png' }}"/>
+  <img [style.max-width]="width" src="/lu-res/{{ (icon.Texture | lowercase) | replace:'dds$':'png' }}"/>
 </ng-container>

--- a/src/app/objects/npc-icon/npc-icon.component.ts
+++ b/src/app/objects/npc-icon/npc-icon.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 import { LuJsonService } from '../../services';
-import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-npc-icon',
@@ -13,13 +12,11 @@ export class NpcIconComponent implements OnInit {
   @Input() id: number;
   @Input() width: string = '64px';
   icon: any;
-  baseUrl: string;
 
   constructor(private luJsonService: LuJsonService) { }
 
   ngOnInit() {
   	this.getIcon();
-    this.baseUrl = environment.data.baseUrl;
   }
 
   getIcon(): void

--- a/src/app/serialize/image/image.component.html
+++ b/src/app/serialize/image/image.component.html
@@ -1,1 +1,1 @@
-<img *ngIf="path" [style.max-width]="width" src="{{baseUrl}}lu-res/textures/ui/{{(path | lowercase) | replace:'dds$':'png' }}" />
+<img *ngIf="path" [style.max-width]="width" src="/lu-res/textures/ui/{{(path | lowercase) | replace:'dds$':'png' }}" />

--- a/src/app/serialize/image/image.component.ts
+++ b/src/app/serialize/image/image.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-image',
@@ -10,10 +9,8 @@ export class ImageComponent implements OnInit {
 
   @Input() path;
   @Input() width: string = '64px';
-  baseUrl: string;
 
   constructor() {
-    this.baseUrl = environment.data.baseUrl;
   }
 
   ngOnInit() {

--- a/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
+++ b/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { environment } from '../../../environments/environment';
 
 import { LuJsonService } from '../../services';
 import { DB_Behavior, DB_BehaviorParameter, DB_BehaviorTemplate } from '../../cdclient';
@@ -28,15 +27,12 @@ export class BehaviorDetailAltComponent implements OnInit {
   max_level: number = 1;
   pending: number = 0;
 
-  baseUrl: string;
-
   selectedBehavior: DB_Behavior;
   errors: number[] = [];
 
   constructor(private route: ActivatedRoute,
     private luJsonService: LuJsonService,
     private luCoreData: LuCoreDataService) {
-    this.baseUrl = environment.data.baseUrl;
   }
 
   callback(id: number, level: number, behavior: DB_Behavior) {
@@ -111,7 +107,7 @@ export class BehaviorDetailAltComponent implements OnInit {
     if (behavior.templateID == 1) {
       node.label = "BasicAttack";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/knight_blade.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/knight_blade.png";
       this.add_child(id, behavior, level, 'on_success', 'success');
       this.add_child(id, behavior, level, 'on_fail_armor', 'fail armor');
       this.add_child(id, behavior, level, 'on_fail_blocked', 'fail blocked');
@@ -119,7 +115,7 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 2) {
       node.label = "TacArc";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_blow_dart.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_blow_dart.png";
       this.add_child(id, behavior, level, 'action', '');
       this.add_child(id, behavior, level, 'blocked action', 'blocked');
     }
@@ -133,7 +129,7 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 4) {
       node.label = "Projectile Attack";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_flaming_arrow.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_flaming_arrow.png";
     }
     else if (behavior.templateID == 5) {
       node.label = "Heal";
@@ -149,18 +145,18 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 7) {
       node.label = "AreaOfEffect";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/bubble_generator.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/bubble_generator.png";
       this.add_child(id, behavior, level, 'action', '');
     }
     else if (behavior.templateID == 8) {
       node.label = "Play Effect";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/disco_ball.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/disco_ball.png";
     }
     else if (behavior.templateID == 12) {
       node.label = "OverTime";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/spark_thrower.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/spark_thrower.png";
       this.add_child(id, behavior, level, 'action', '');
     }
     else if (behavior.templateID == 13) {
@@ -173,23 +169,23 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 15) {
       node.label = "Stun";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/bonedaddy.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/bonedaddy.png";
     }
     else if (behavior.templateID == 16) {
       node.label = "Duration";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/spark_thrower.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/spark_thrower.png";
       this.add_child(id, behavior, level, 'action', '');
     }
     else if (behavior.templateID == 17) {
       node.label = "Knockback";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_repulsion.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_repulsion.png";
     }
     else if (behavior.templateID == 18) {
       node.label = "AttackDelay";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/turtle_rush.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/turtle_rush.png";
       this.add_child(id, behavior, level, 'action', '');
     }
     else if (behavior.templateID == 22) {
@@ -200,14 +196,14 @@ export class BehaviorDetailAltComponent implements OnInit {
     }
     else if (behavior.templateID == 25) {
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_lucky.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_lucky.png";
       node.label = "LootBuff";
     }
     else if (behavior.templateID == 27) // e.g. 4417
     {
       node.label = "Spawn";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/crabby.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/crabby.png";
     }
     else if (behavior.templateID == 29) {
       node.label = "Switch";
@@ -223,12 +219,12 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 34) {
       node.label = "Skill Cast\nFailed";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_marks_the_spot.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_marks_the_spot.png";
     }
     else if (behavior.templateID == 37) {
       node.label = "ApplyBuff";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_health_buff.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_health_buff.png";
     }
     else if (behavior.templateID == 38) {
       node.label = "Chain";
@@ -240,7 +236,7 @@ export class BehaviorDetailAltComponent implements OnInit {
     }
     else if (behavior.templateID == 39) {
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_whirlwind.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_whirlwind.png";
       node.label = "ChangeOrientation";
     }
     else if (behavior.templateID == 40) {
@@ -249,12 +245,12 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 41) {
       node.label = "Interrupt";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_marks_the_spot.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_marks_the_spot.png";
     }
     else if (behavior.templateID == 42) {
       node.label = "AlterCooldown";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/spark_thrower.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/spark_thrower.png";
     }
     else if (behavior.templateID == 43) {
       node.label = "ChargeUp";
@@ -271,7 +267,7 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 45) {
       node.label = "Start";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_freebuild.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_freebuild.png";
       this.add_child(id, behavior, level, 'action');
     }
     else if (behavior.templateID == 46) {
@@ -280,12 +276,12 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 47) {
       node.label = "AlterChainDelay";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/spark_thrower.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/spark_thrower.png";
     }
     else if (behavior.templateID == 51) {
       node.label = "ModularBuild";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/hats/thinking_hat.png';
+      node.image = "/lu-res/textures/ui/inventory/hats/thinking_hat.png";
     }
     else if (behavior.templateID == 52) {
       node.label = "NPC\nCombat\nSkill";
@@ -309,7 +305,7 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 56) {
       node.label = "AirMovement";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/body_slam.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/body_slam.png";
       this.add_child(id, behavior, level, 'ground_action', 'ground');
       this.add_child(id, behavior, level, 'hit_action', 'hit');
       this.add_child(id, behavior, level, 'hit_action_enemy', 'hit enemy');
@@ -318,7 +314,7 @@ export class BehaviorDetailAltComponent implements OnInit {
     else if (behavior.templateID == 58) {
       node.label = "PullToPoint";
       node.shape = 'image';
-      node.image = this.baseUrl + 'lu-res/textures/ui/inventory/skills/skills_snap_trap.png';
+      node.image = "/lu-res/textures/ui/inventory/skills/skills_snap_trap.png";
     }
   }
 

--- a/src/app/util/icon/icon.component.html
+++ b/src/app/util/icon/icon.component.html
@@ -1,4 +1,4 @@
 <img *ngIf="icon && icon.IconPath" class="icon" [style.max-width]="width"
-    src="{{baseUrl}}lu-res/textures/ui/{{(icon.IconPath | lowercase) | replace:'dds$':'png' }}"
+    src="/lu-res/textures/ui/{{(icon.IconPath | lowercase) | replace:'dds$':'png' }}"
     [title]="(icon && caption && icon.IconName) ? icon.IconName : ''"
     [alt]="(icon && caption && icon.IconName) ? icon.IconName : ''"/>

--- a/src/app/util/icon/icon.component.ts
+++ b/src/app/util/icon/icon.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { environment } from '../../../environments/environment';
 
 import { LuJsonService } from '../../services';
 import { DB_Icons } from '../../cdclient';
@@ -15,10 +14,8 @@ export class IconComponent implements OnInit {
   @Input() width: string = '64px';
   @Input() caption: boolean = true;
   icon: DB_Icons;
-  baseUrl: string;
 
   constructor(private luJsonService: LuJsonService) {
-    this.baseUrl = environment.data.baseUrl;
   }
 
   ngOnInit() {

--- a/src/app/util/services/lu-docs.service.ts
+++ b/src/app/util/services/lu-docs.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -9,13 +8,7 @@ export class LuDocsService {
   baseUrl: string;
 
   constructor() {
-    if (environment.production) {
-      // using public API
-      this.baseUrl = 'https://lu-docs.readthedocs.io/';
-    } else {
-      // serving API locally
-      this.baseUrl = 'http://localhost:8000/lu-docs/';
-    }
+    this.baseUrl = '/lu-docs/';
   }
 
   link(path: string): string {

--- a/src/app/util/services/lu-json.service.ts
+++ b/src/app/util/services/lu-json.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { ReplaySubject, Observable, of } from 'rxjs';
 import { catchError, find, map, tap } from 'rxjs/operators';
 
-import { environment } from '../../../environments/environment';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 import { MessageService } from './message.service';
@@ -36,7 +35,6 @@ export class Optional<T> {
 @Injectable()
 export class LuJsonService {
 
-  private baseUrl;
   private apiUrl;
   private tablesUrl;
   private localeUrl;
@@ -65,10 +63,9 @@ export class LuJsonService {
     private http: HttpClient,
     private messageService: MessageService) {
 
-    this.baseUrl = environment.data.baseUrl;
     this.jsonStore = {};
 
-    this.apiUrl = this.baseUrl + "lu-json/";
+    this.apiUrl = "/lu-json/";
 
     this.tablesUrl = "tables/";
     this.localeUrl = "locale/";

--- a/src/app/util/services/lu-res.service.ts
+++ b/src/app/util/services/lu-res.service.ts
@@ -2,25 +2,21 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LuResService {
 
-  private baseUrl: string = "";
-
   constructor(private http: HttpClient) {
-    this.baseUrl = environment.data.baseUrl;
   }
 
   getBaseUrl(): string {
-    return this.baseUrl;
+    return "/";
   }
 
   getResolvedResUrl(path: string): string {
-    return this.baseUrl + 'lu-res/' + path;
+    return "/lu-res/" + path;
   }
 
   getXML(path: string): Observable<XMLDocument> {

--- a/src/app/util/services/lu-res.service.ts
+++ b/src/app/util/services/lu-res.service.ts
@@ -11,10 +11,6 @@ export class LuResService {
   constructor(private http: HttpClient) {
   }
 
-  getBaseUrl(): string {
-    return "/";
-  }
-
   getResolvedResUrl(path: string): string {
     return "/lu-res/" + path;
   }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,7 +1,6 @@
 export const environment = {
   production: true,
   data: {
-    baseUrl: "https://xiphoseer.de/",
     apiUrl: "https://lu.lcdruniverse.org/explorer/api/"
   },
   firebase: {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,7 +6,6 @@
 export const environment = {
   production: false,
   data: {
-    baseUrl: "http://localhost:8000/",
     apiUrl: "https://lu.lcdruniverse.org/explorer/api/"
   },
   firebase: {

--- a/src/index.html
+++ b/src/index.html
@@ -10,13 +10,13 @@
   <meta property="og:type" content="website" />
   <meta property="og:description" content="Check out the LEGO Universe Game Data" />
   <meta property="og:url" content="https://lu.lcdruniverse.org/explorer/" />
-  <meta property="og:image" content="https://xiphoseer.de/lu-res/ui/ingame/freetrialcongratulations_id.png" />
+  <meta property="og:image" content="/lu-res/ui/ingame/freetrialcongratulations_id.png" />
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@lu_explorer" />
   <meta name="twitter:title" content="LEGO Universe Explorer" />
   <meta name="twitter:description" content="Check out the LEGO Universe Game Data" />
-  <meta name="twitter:image" content="https://xiphoseer.de/lu-res/ui/ingame/freetrialcongratulations_id.png" />
+  <meta name="twitter:image" content="/lu-res/ui/ingame/freetrialcongratulations_id.png" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -1,0 +1,15 @@
+
+{
+  "/lu-docs": {
+    "target": "http://localhost:8000",
+    "secure": false
+  },
+  "/lu-json": {
+    "target": "http://localhost:8000",
+    "secure": false
+  },
+  "/lu-res": {
+    "target": "http://localhost:8000",
+    "secure": false
+  }
+}


### PR DESCRIPTION
This changes lu-explorer so that URLs no longer need to be manually changed to support the dev server setup. Instead, Angular's proxy support is used to reroute these requests when `ng serve` is used. The production environment will now need to serve lu-docs, lu-json, and lu-res itself or proxy to a server that does (this is already set up for lu.lcdruniverse.org). I've confirmed that the proxying works by setting the proxy in `src/proxy.conf.json` to `https://lu.lcdruniverse.org` locally (this is not committed, this PR sets the proxy to use `localhost:8000` like it used to be).