### PR TITLE
Use simple flag components in the mission detail view

### DIFF
--- a/src/app/gui/simple-flag/simple-flag.component.html
+++ b/src/app/gui/simple-flag/simple-flag.component.html
@@ -1,4 +1,4 @@
-<span class="flag-container" [title]="title ? title : ''">
+<span class="flag-container" [title]="valueTitle()">
   <img class="value" [src]="valueImg()"/><br>
   <span class="key">{{name}}</span>
 </span>

--- a/src/app/gui/simple-flag/simple-flag.component.ts
+++ b/src/app/gui/simple-flag/simple-flag.component.ts
@@ -8,7 +8,9 @@ import { Component, Input, OnInit } from '@angular/core';
 export class SimpleFlagComponent implements OnInit {
   @Input() name: string;
   @Input() value: boolean;
-  @Input() title: string;
+  @Input() title: string = "";
+  @Input() trueTitle: string = "";
+  @Input() falseTitle: string = "";
 
   private trueImg: string;
   private falseImg: string;
@@ -24,4 +26,14 @@ export class SimpleFlagComponent implements OnInit {
     return this.value ? this.trueImg : this.falseImg;
   }
 
+  valueTitle() {
+    if (this.title) {
+      return this.title;
+    }
+    if (this.value) {
+      return this.trueTitle;
+    } else {
+      return this.falseTitle;
+    }
+  }
 }

--- a/src/app/missions/detail/detail.component.html
+++ b/src/app/missions/detail/detail.component.html
@@ -74,21 +74,12 @@
 
 <section id="flags" *ngIf="mission">
   <h3>Flags</h3>
-  <ul>
-    <li *ngIf="mission.isMission === false">This is an achievement (<code>isMission == false</code>)</li>
-    <li *ngIf="mission.isMission === true">This is a mission (<code>isMission == true</code>)</li>
-    <li *ngIf="mission.repeatable === false">The player can only complete this once (<code>repeatable == false</code>)
-    </li>
-    <li *ngIf="mission.repeatable === true">The player can complete this multiple times
-      (<code>repeatable == true</code>)</li>
-    <li><code>isRandom == {{mission.isRandom}}</code></li>
-    <li *ngIf="mission.isChoiceReward === false">The player cannot choose their reward
-      (<code>isChoiceReward == false</code>)</li>
-    <li *ngIf="mission.isChoiceReward === true">The player can choose their reward (<code>isChoiceReward == true</code>)
-    </li>
-    <li *ngIf="mission.inMOTD === false">This may not be a <em>mission-of-the-day</em> (<code>inMOTD == false</code>)
-    </li>
-    <li *ngIf="mission.inMOTD === true">This may be a <em>mission-of-the-day</em> (<code>inMOTD == true</code>)</li>
+  <lux-simple-flag name="isMission" [value]="mission.isMission" trueTitle="This is a mission." falseTitle="This is an achievement."></lux-simple-flag>
+  <lux-simple-flag name="repeatable" [value]="mission.repeatable" trueTitle="The player can complete this multiple times." falseTitle="The player can only complete this once."></lux-simple-flag>
+  <lux-simple-flag name="isRandom" [value]="mission.isRandom" trueTitle="This mission is part of a random pool." falseTitle="This mission is not part of a random pool."></lux-simple-flag>
+  <lux-simple-flag name="isChoiceReward" [value]="mission.isChoiceReward" trueTitle="The player must choose one of the reward items offered." falseTitle="The player receives all rewards."></lux-simple-flag>
+  <lux-simple-flag name="inMOTD" [value]="mission.inMOTD" trueTitle="This may be a mission-of-the-day." falseTitle="This may not be a mission-of-the-day."></lux-simple-flag>
+	<ul>
     <li *ngIf="mission.gate_version">This task is only available with a feature update / gate
       (<code>gate_version</code>):
       <ul>

--- a/src/app/objects/components/item-component/item-component.component.html
+++ b/src/app/objects/components/item-component/item-component.component.html
@@ -125,8 +125,8 @@
     <h4>Flags</h4>
     <lux-simple-flag name="inLootTable" [value]="item.inLootTable"></lux-simple-flag>
     <lux-simple-flag name="inVendor" [value]="item.inVendor"></lux-simple-flag>
-    <lux-simple-flag name="isBOE" [value]="item.isBOE" title="Bound on Equip"></lux-simple-flag>
-    <lux-simple-flag name="isBOP" [value]="item.isBOP" title="Bound on Pickup"></lux-simple-flag>
+    <lux-simple-flag name="isBOE" [value]="item.isBOE" trueTitle="This item cannot be traded once it has been equipped (bound on equip)." falseTitle="This item is not bound on equip."></lux-simple-flag>
+    <lux-simple-flag name="isBOP" [value]="item.isBOP" trueTitle="This item cannot be traded (bound on pickup)." falseTitle="This item is not bound on pickup."></lux-simple-flag>
     <lux-simple-flag name="isKitPiece" [value]="item.isKitPiece"></lux-simple-flag>
     <lux-simple-flag name="isTwoHanded" [value]="item.isTwoHanded"></lux-simple-flag>
     <lux-simple-flag name="isUnique" [value]="item.isUnique"></lux-simple-flag>


### PR DESCRIPTION
This changes the mission detail view to display boolean flags using the nicer simple flag UI instead of the textual descriptions. I wanted to keep the descriptions as further explanation, so I extended the simple flag component to support state-specific tooltips, and updated the usages in the item component view to make use of them as well.