### PR TITLE
Display mission stat and emote rewards as slots

### DIFF
--- a/src/app/gui/gui.module.ts
+++ b/src/app/gui/gui.module.ts
@@ -17,6 +17,7 @@ import { PreconditionTreeComponent } from './precondition-tree/precondition-tree
 import { BuffFlagComponent } from './buff-flag/buff-flag.component';
 import { ReputationComponent } from './reputation/reputation.component';
 import { UscoreComponent } from './uscore/uscore.component';
+import { SlotComponent } from './slot/slot.component';
 
 
 @NgModule({
@@ -31,6 +32,7 @@ import { UscoreComponent } from './uscore/uscore.component';
     BuffFlagComponent,
     ReputationComponent,
     UscoreComponent,
+    SlotComponent,
   ],
   imports: [
     CommonModule,
@@ -48,6 +50,7 @@ import { UscoreComponent } from './uscore/uscore.component';
     BuffFlagComponent,
     ReputationComponent,
     UscoreComponent,
+    SlotComponent,
   ],
 })
 export class GuiModule { }

--- a/src/app/gui/item/item.component.css
+++ b/src/app/gui/item/item.component.css
@@ -1,60 +1,11 @@
-:host {
-    position: relative;
-    width: 64px;
-    height: 64px;
-    display: inline-block;
-    margin: 2px;
-}
-
-.slot {
-    position: relative;
-    vertical-align: middle;
-    display: inline-block;
-    width: 64px;
-    height: 64px;
-    box-sizing: border-box;
-    background-color: #000;
-    border-radius: 10px;
-}
-
-.slot .id {
-    line-height: 64px;
-    text-align: center;
-    width: 100%;
-    display: inline-block;
-    font-weight: bold;
-}
-
-.icon {
-    width: 48px;
-    height: 48px;
-    padding: 5px;
-    margin: 3px;
-}
-
-.equipped {
-    background-color: #f90;
-}
-
-.number {
-    position: absolute;
-    bottom: 5px;
-    right: 10px;
-    color: white;
-    display: block;
-    font-weight: bold;
-}
-
-.equipped .number {
-    color: #000;
-}
-
 .tooltip-title {
     display: block;
     padding: 5px;
-    background: #555;
-    border-radius: 5px;
-    font-weight: bold;
+    background: rgba(85, 85, 85, 0.6);
+    border-radius: 12px;
+    font-weight: 600;
     text-align: center;
+    margin-top: 3px;
     margin-bottom: 3px;
+		width: 200px;
 }

--- a/src/app/gui/item/item.component.html
+++ b/src/app/gui/item/item.component.html
@@ -1,20 +1,13 @@
-<ng-container *ngIf="id | data:'object' | async; else notFound; let object">
-    <a routerLink="/objects/{{id}}" class="slot" [class.equipped]="equipped"
-        [luxTooltip]="tooltip">
-        <ng-template #tooltip>
-            <span class="tooltip-title">{{ object['displayName'] || object['name'] }}</span>
-            Template ID: {{id}}
-        </ng-template>
-        <ng-container *ngIf="object['components']['2'] | data:'renderComponent' | async; else noRender; let render">
-            <img class="icon" *ngIf="render['icon_asset']; else noRender; let icon_asset"
-                [src]="'textures/ui/' + icon_asset | lowercase | replace:'dds$':'png' | res" />
-        </ng-container>
-        <ng-template #noRender><span class="id">{{id}}</span></ng-template>
-        <span class="number" *ngIf="amount > 0">{{amount}}</span>
-    </a>
+<ng-container *ngIf="id | data:'object' | async; else error; let object">
+  <ng-container *ngIf="object['components']['2'] | data:'renderComponent' | async; else error; let render">
+    <ng-container *ngIf="render['icon_asset']; else error; let icon_asset">
+      <lux-slot [count]="amount" [equipped]="equipped" link="/objects/{{id}}" [icon]="'textures/ui/' + icon_asset | lowercase | replace:'dds$':'png' | res">
+        <span class="tooltip-title">{{ object['displayName'] || object['name'] }}</span>
+        Template ID: {{id}}
+      </lux-slot>
+    </ng-container>
+  </ng-container>
 </ng-container>
-<ng-template #notFound>
-    <span class="slot">
-        <span class="id">{{id}}</span>
-    </span>
+<ng-template #error>
+  <lux-slot [count]="amount" [equipped]="equipped" link="/objects/{{id}}"></lux-slot>
 </ng-template>

--- a/src/app/gui/slot/slot.component.css
+++ b/src/app/gui/slot/slot.component.css
@@ -1,0 +1,35 @@
+:host {
+    background-color: #000;
+    border-radius: 10px;
+    box-sizing: border-box;
+    display: inline-block;
+    height: 64px;
+    margin: 2px;
+    position: relative;
+    vertical-align: middle;
+    width: 64px;
+}
+
+.icon {
+    width: 48px;
+    height: 48px;
+    padding: 5px;
+    margin: 3px;
+}
+
+.count {
+    bottom: 5px;
+    color: white;
+    display: block;
+    font-weight: bold;
+    position: absolute;
+    right: 10px;
+}
+
+:host[ng-reflect-equipped=true] {
+    background-color: rgb(209, 111, 5);
+}
+
+:host[ng-reflect-equipped=true] .count {
+    color: #000;
+}

--- a/src/app/gui/slot/slot.component.html
+++ b/src/app/gui/slot/slot.component.html
@@ -1,0 +1,7 @@
+<a [routerLink]="link" [luxTooltip]="tooltip">
+	<ng-template #tooltip>
+		<ng-content></ng-content>
+	</ng-template>
+  <img class="icon" [src]="icon"/>
+  <span class="count" *ngIf="count > 1">{{count}}</span>
+</a>

--- a/src/app/gui/slot/slot.component.spec.ts
+++ b/src/app/gui/slot/slot.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { SlotComponent } from "./slot.component";
+
+describe("SlotComponent", () => {
+  let component: SlotComponent;
+  let fixture: ComponentFixture<SlotComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SlotComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SlotComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/gui/slot/slot.component.ts
+++ b/src/app/gui/slot/slot.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, OnInit } from "@angular/core";
+
+@Component({
+  selector: "lux-slot",
+  templateUrl: "./slot.component.html",
+  styleUrls: ["./slot.component.css"]
+})
+export class SlotComponent implements OnInit {
+  @Input() count: number = -1;
+  @Input() equipped: boolean = false;
+  @Input() link: string;
+  @Input() icon: string = "/lu-res/textures/ui/inventory/unknown.png";
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/gui/tooltip/tooltip.component.css
+++ b/src/app/gui/tooltip/tooltip.component.css
@@ -1,15 +1,20 @@
-.tooltip-container {
+:host {
     /* Position the tooltip text */
     position: absolute;
     top: 0;
     left: 70px;
     z-index: 100;
 
-    background-color: black;
-    color: white;
-    padding: 10px;
-    border-radius: 10px;
-    min-width: 200px;
+    display: block;
+    width: 450px;
+}
 
-    border: 1px solid white;
+.tooltip-container {
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+		display: inline-block;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 20px;
+    text-align: center;
 }

--- a/src/app/missions/detail/detail.component.html
+++ b/src/app/missions/detail/detail.component.html
@@ -79,7 +79,7 @@
   <lux-simple-flag name="isRandom" [value]="mission.isRandom" trueTitle="This mission is part of a random pool." falseTitle="This mission is not part of a random pool."></lux-simple-flag>
   <lux-simple-flag name="isChoiceReward" [value]="mission.isChoiceReward" trueTitle="The player must choose one of the reward items offered." falseTitle="The player receives all rewards."></lux-simple-flag>
   <lux-simple-flag name="inMOTD" [value]="mission.inMOTD" trueTitle="This may be a mission-of-the-day." falseTitle="This may not be a mission-of-the-day."></lux-simple-flag>
-	<ul>
+  <ul>
     <li *ngIf="mission.gate_version">This task is only available with a feature update / gate
       (<code>gate_version</code>):
       <ul>
@@ -101,23 +101,6 @@
 
 <section *ngIf="mission">
   <h3>Rewards</h3>
-  <ul>
-    <li *ngIf="mission.reward_maxhealth > 0">The player's maximum health is increased by {{mission.reward_maxhealth}}
-    </li>
-    <li *ngIf="mission.reward_maximagination > 0">The player's maximum imagination is increased by
-      {{mission.reward_maximagination}}</li>
-    <li *ngIf="mission.reward_maxinventory > 0">The player's backpack size is increased by
-      {{mission.reward_maxinventory}}</li>
-    <li *ngIf="mission.reward_maxmodel > 0">The player's model backpack size is increased by {{mission.reward_maxmodel}}
-    </li>
-    <li *ngIf="mission.reward_maxwidget > 0">The player's widget backpack size is increased by
-      {{mission.reward_maxwidget}}</li>
-    <li *ngIf="mission.reward_maxwallet > 0">The player's maximum coin count is increased by
-      {{mission.reward_maxwallet}} coins</li>
-    <li *ngIf="mission.reward_bankinventory > 0">The player's maximum vault inventory size is increased by
-      {{mission.reward_bankinventory}}</li>
-  </ul>
-
   <dl>
     <dt *ngIf="mission.isChoiceReward">The player can choose one of:</dt>
     <dt *ngIf="!mission.isChoiceReward">The player receives:</dt>
@@ -130,11 +113,18 @@
       </lux-gui-item>
       <lux-gui-item *ngIf="mission.reward_item4 > -1" [id]="mission.reward_item4" [amount]="mission.reward_item4_count">
       </lux-gui-item>
+      <lux-slot *ngIf="mission.reward_maxhealth > 0" icon="/lu-res/textures/ui/rewards/maxheart.png" [count]="mission.reward_maxhealth">Life Point</lux-slot>
+      <lux-slot *ngIf="mission.reward_maximagination > 0" icon="/lu-res/textures/ui/rewards/maximagination.png" [count]="mission.reward_maximagination">Imagination Point</lux-slot>
+      <lux-slot *ngIf="mission.reward_maxinventory > 0" icon="/lu-res/textures/ui/rewards/maxinventory.png" [count]="mission.reward_maxinventory">Extra Backpack Space</lux-slot>
+      <lux-slot *ngIf="mission.reward_maxmodel > 0" icon="/lu-res/textures/ui/rewards/maxmodel.png" [count]="mission.reward_maxmodel">Extra Model Space</lux-slot>
+      <lux-slot *ngIf="mission.reward_maxwidget > 0" icon="/lu-res/textures/ui/rewards/maxwidget.png" [count]="mission.reward_maxwidget">Extra Behavior Space</lux-slot>
+      <lux-slot *ngIf="mission.reward_maxwallet > 0" icon="/lu-res/textures/ui/rewards/maxwallet.png" [count]="mission.reward_maxwallet">Extra Wallet Space"</lux-slot>
+      <lux-slot *ngIf="mission.reward_bankinventory > 0" icon="/lu-res/textures/ui/rewards/maxbank.png" [count]="mission.reward_bankinventory">Extra Vault Space</lux-slot>
+      <lux-slot *ngIf="mission.reward_emote > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote}}</lux-slot>
+      <lux-slot *ngIf="mission.reward_emote2 > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote2}}</lux-slot>
+      <lux-slot *ngIf="mission.reward_emote3 > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote3}}</lux-slot>
+      <lux-slot *ngIf="mission.reward_emote4 > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote4}}</lux-slot>
     </dd>
-    <dd *ngIf="mission.reward_emote > -1">the emote #{{mission.reward_emote}}</dd>
-    <dd *ngIf="mission.reward_emote2 > -1">the emote #{{mission.reward_emote2}}</dd>
-    <dd *ngIf="mission.reward_emote3 > -1">the emote #{{mission.reward_emote3}}</dd>
-    <dd *ngIf="mission.reward_emote4 > -1">the emote #{{mission.reward_emote4}}</dd>
   </dl>
 
   <ul class="currency-rewards">
@@ -162,49 +152,6 @@
     <li *ngIf="mission.reward_currency_repeatable > 0"><lux-coins [count]="mission.reward_currency_repeatable"></lux-coins></li>
     <li *ngIf="mission.LegoScore > 0"><lux-uscore [count]="mission.LegoScore"></lux-uscore></li>
   </ul>
-
-  <!--  <table>
-    <tr>
-      <th></th>
-      <th>itemid</th>
-      <th>count</th>
-      <th>repeat_count</th>
-      <th>repeatable</th>
-      <th>emote</th>
-    </tr>
-    <tr>
-      <th>reward 1</th>
-      <td>{{mission.reward_item1}}</td>
-      <td>{{mission.reward_item1_count}}</td>
-      <td>{{mission.reward_item1_repeat_count}}</td>
-      <td>{{mission.reward_item1_repeatable}}</td>
-      <td>{{mission.reward_emote}}</td>
-    </tr>
-    <tr>
-      <th>reward 2</th>
-      <td>{{mission.reward_item2}}</td>
-      <td>{{mission.reward_item2_count}}</td>
-      <td>{{mission.reward_item2_repeat_count}}</td>
-      <td>{{mission.reward_item2_repeatable}}</td>
-      <td>{{mission.reward_emote2}}</td>
-    </tr>
-    <tr>
-      <th>reward 3</th>
-      <td>{{mission.reward_item3}}</td>
-      <td>{{mission.reward_item3_count}}</td>
-      <td>{{mission.reward_item3_repeat_count}}</td>
-      <td>{{mission.reward_item3_repeatable}}</td>
-      <td>{{mission.reward_emote3}}</td>
-    </tr>
-    <tr>
-      <th>reward 4</th>
-      <td>{{mission.reward_item4}}</td>
-      <td>{{mission.reward_item4_count}}</td>
-      <td>{{mission.reward_item4_repeat_count}}</td>
-      <td>{{mission.reward_item4_repeatable}}</td>
-      <td>{{mission.reward_emote4}}</td>
-    </tr>
-  </table>-->
 </section>
 
 <h3>Texts</h3>


### PR DESCRIPTION
Mission stat and emote rewards are changed to be shown as slots, like items, instead of a textual description. To make this work I created a slot component as a lower level version of the gui-item component, which allows link and icon to be set directly, with gui-item now using the slot component internally. I also slightly adjusted the tooltip styling to be closer to LU's tooltips.