### PR TITLE
Rework tooltips

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, ViewContainerRef } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
 
 function isFunction(functionToCheck) {
   return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
-} 
+}
 
 @Component({
   selector: 'app-root',
@@ -16,6 +16,7 @@ export class AppComponent {
   title = 'LEGO® Universe Explorer';
 
   constructor(private router: Router,
+    private viewContainerRef: ViewContainerRef,
     private activatedRoute: ActivatedRoute,
     private titleService: Title) {
 

--- a/src/app/gui/item/item.component.html
+++ b/src/app/gui/item/item.component.html
@@ -1,10 +1,11 @@
 <ng-container *ngIf="id | data:'object' | async; else error; let object">
   <ng-container *ngIf="object['components']['2'] | data:'renderComponent' | async; else error; let render">
     <ng-container *ngIf="render['icon_asset']; else error; let icon_asset">
-      <lux-slot [count]="amount" [equipped]="equipped" link="/objects/{{id}}" [icon]="'textures/ui/' + icon_asset | lowercase | replace:'dds$':'png' | res">
+      <lux-slot [count]="amount" [equipped]="equipped" link="/objects/{{id}}" [icon]="'textures/ui/' + icon_asset | lowercase | replace:'dds$':'png' | res" [luxTooltip]="tooltip"></lux-slot>
+      <ng-template #tooltip>
         <span class="tooltip-title">{{ object['displayName'] || object['name'] }}</span>
         Template ID: {{id}}
-      </lux-slot>
+      </ng-template>
     </ng-container>
   </ng-container>
 </ng-container>

--- a/src/app/gui/slot/slot.component.html
+++ b/src/app/gui/slot/slot.component.html
@@ -1,7 +1,4 @@
-<a [routerLink]="link" [luxTooltip]="tooltip">
-	<ng-template #tooltip>
-		<ng-content></ng-content>
-	</ng-template>
+<a [routerLink]="link">
   <img class="icon" [src]="icon"/>
   <span class="count" *ngIf="count > 1">{{count}}</span>
 </a>

--- a/src/app/gui/tooltip.directive.ts
+++ b/src/app/gui/tooltip.directive.ts
@@ -1,4 +1,4 @@
-import { ComponentFactory, ComponentFactoryResolver, ComponentRef, Directive, ElementRef, EmbeddedViewRef, HostListener, Injector, Input, ReflectiveInjector, Renderer2, TemplateRef, Type, ViewContainerRef } from '@angular/core';
+import { ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, Directive, ElementRef, EmbeddedViewRef, HostListener, Injector, Input, ReflectiveInjector, Renderer2, TemplateRef, Type, ViewContainerRef } from '@angular/core';
 import { TooltipComponent } from './tooltip/tooltip.component';
 
 @Directive({
@@ -13,10 +13,10 @@ export class TooltipDirective {
   private configInjector: Injector;
 
   constructor(private element: ElementRef<HTMLElement>,
+    private applicationRef: ApplicationRef,
     private renderer: Renderer2,
     private injector: Injector,
-    private resolver: ComponentFactoryResolver,
-    private vcr: ViewContainerRef) {
+    private resolver: ComponentFactoryResolver) {
     this.factory = this.resolver.resolveComponentFactory(TooltipComponent);
     this.configInjector = Injector.create({
       providers: [
@@ -37,8 +37,19 @@ export class TooltipDirective {
     if (this.componentRef) return;
     console.log("enter!");
 
-    this.componentRef = //this.vcr.createEmbeddedView(this.content);
-    this.vcr.createComponent(this.factory, 0, this.configInjector, this.generateNgContent());
+    this.componentRef = //
+    this.getRootViewContainerRef().createComponent(this.factory, 0, this.configInjector, this.generateNgContent());
+  }
+
+  getRootViewContainerRef(): ViewContainerRef {
+    const appInstance = this.applicationRef.components[0].instance;
+
+    if (!appInstance.viewContainerRef) {
+      const appName = this.applicationRef.componentTypes[0].name;
+      throw new Error(`Missing 'viewContainerRef' declaration in ${appName} constructor`);
+    }
+
+    return appInstance.viewContainerRef;
   }
 
   generateNgContent() {
@@ -52,7 +63,8 @@ export class TooltipDirective {
       //const context = { id: 100 };
       this.embeddedViewRef = this.content.createEmbeddedView(this.element);
       // In earlier versions, you may need to add this line
-      // this.appRef.attachView(viewRef);
+      // this.applicationRef.attachView(this.embeddedViewRef);
+      this.embeddedViewRef.detectChanges();
       return [this.embeddedViewRef.rootNodes];
     }
 

--- a/src/app/gui/tooltip.directive.ts
+++ b/src/app/gui/tooltip.directive.ts
@@ -5,7 +5,7 @@ import { TooltipComponent } from './tooltip/tooltip.component';
   selector: '[luxTooltip]'
 })
 export class TooltipDirective {
-  @Input('luxTooltip') content: /*string |*/ TemplateRef<any> /*| Type<any>*/;
+  @Input('luxTooltip') content: string | TemplateRef<any> /*| Type<any>*/;
 
   private embeddedViewRef?: EmbeddedViewRef<TooltipComponent>;
   private componentRef: ComponentRef<TooltipComponent>;

--- a/src/app/gui/tooltip/tooltip.component.css
+++ b/src/app/gui/tooltip/tooltip.component.css
@@ -1,18 +1,10 @@
-:host {
-    /* Position the tooltip text */
-    position: absolute;
-    top: 0;
-    left: 70px;
-    z-index: 100;
-
-    display: block;
-    width: 450px;
-}
-
 .tooltip-container {
+    position: absolute;
+    z-index: 100;
+    max-width: 430px;
     background-color: rgba(0, 0, 0, 0.8);
     color: white;
-		display: inline-block;
+    display: inline-block;
     font-weight: 600;
     padding: 4px 10px;
     border-radius: 20px;

--- a/src/app/gui/tooltip/tooltip.component.html
+++ b/src/app/gui/tooltip/tooltip.component.html
@@ -1,3 +1,3 @@
-<div class="tooltip-container">
+<div class="tooltip-container" #tooltipContainer style="top: {{top}}px; left: {{left}}px;">
   <ng-content></ng-content>
 </div>

--- a/src/app/gui/tooltip/tooltip.component.ts
+++ b/src/app/gui/tooltip/tooltip.component.ts
@@ -1,9 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy, Input, Directive, ViewChild, ElementRef, Inject } from '@angular/core';
-
-@Directive({
-  selector: '.tooltip-container'
-})
-export class TooltipContainerDirective {}
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, Input, Directive, ViewChild, ElementRef, Inject } from '@angular/core';
 
 @Component({
   selector: 'lux-tooltip',
@@ -12,24 +7,29 @@ export class TooltipContainerDirective {}
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TooltipComponent implements OnInit {
-  top : string = "64px";
+  top: number = 10;
+  left: number = 10;
 
-  @ViewChild(TooltipContainerDirective, { read: ElementRef })
-  private tooltipContainer!: ElementRef;
+  @ViewChild("tooltipContainer")
+  private tooltipContainer: ElementRef;
 
-  constructor( @Inject('tooltipConfig') private config ) {}
-  
+  constructor(@Inject('tooltipConfig') private config, private changeDetector: ChangeDetectorRef) {}
+
   ngOnInit() {}
 
   ngAfterViewInit() {
-    // For simplicity, we calculate only the top.
-    const { top } = this.config.host.getBoundingClientRect();
-    if (this.tooltipContainer) {
-      const { height } = this.tooltipContainer.nativeElement.getBoundingClientRect();
-      //this.top = `${top - height}px`;
-    } else {
-      console.log(this.tooltipContainer);
-    }
+    // position tooltip at top center of host
+    const hostRect = this.config.host.getBoundingClientRect();
+    this.top = window.scrollY + hostRect.top;
+    this.left = window.scrollX + hostRect.left + hostRect.width/2;
+    const tooltipRect = this.tooltipContainer.nativeElement.getBoundingClientRect();
+    // shift tooltip to be fully above referenced element
+    this.top -= tooltipRect.height;
+    // shift tooltip to be centered properly
+    this.left -= tooltipRect.width/2;
+    // clamp to window dimensions to avoid tooltips going out of bounds
+    this.left = Math.max(10, Math.min(window.innerWidth - 10 - tooltipRect.width, this.left));
+    this.changeDetector.detectChanges();
   }
 
 }

--- a/src/app/missions/detail/detail.component.html
+++ b/src/app/missions/detail/detail.component.html
@@ -113,17 +113,17 @@
       </lux-gui-item>
       <lux-gui-item *ngIf="mission.reward_item4 > -1" [id]="mission.reward_item4" [amount]="mission.reward_item4_count">
       </lux-gui-item>
-      <lux-slot *ngIf="mission.reward_maxhealth > 0" icon="/lu-res/textures/ui/rewards/maxheart.png" [count]="mission.reward_maxhealth">Life Point</lux-slot>
-      <lux-slot *ngIf="mission.reward_maximagination > 0" icon="/lu-res/textures/ui/rewards/maximagination.png" [count]="mission.reward_maximagination">Imagination Point</lux-slot>
-      <lux-slot *ngIf="mission.reward_maxinventory > 0" icon="/lu-res/textures/ui/rewards/maxinventory.png" [count]="mission.reward_maxinventory">Extra Backpack Space</lux-slot>
-      <lux-slot *ngIf="mission.reward_maxmodel > 0" icon="/lu-res/textures/ui/rewards/maxmodel.png" [count]="mission.reward_maxmodel">Extra Model Space</lux-slot>
-      <lux-slot *ngIf="mission.reward_maxwidget > 0" icon="/lu-res/textures/ui/rewards/maxwidget.png" [count]="mission.reward_maxwidget">Extra Behavior Space</lux-slot>
-      <lux-slot *ngIf="mission.reward_maxwallet > 0" icon="/lu-res/textures/ui/rewards/maxwallet.png" [count]="mission.reward_maxwallet">Extra Wallet Space"</lux-slot>
-      <lux-slot *ngIf="mission.reward_bankinventory > 0" icon="/lu-res/textures/ui/rewards/maxbank.png" [count]="mission.reward_bankinventory">Extra Vault Space</lux-slot>
-      <lux-slot *ngIf="mission.reward_emote > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote}}</lux-slot>
-      <lux-slot *ngIf="mission.reward_emote2 > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote2}}</lux-slot>
-      <lux-slot *ngIf="mission.reward_emote3 > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote3}}</lux-slot>
-      <lux-slot *ngIf="mission.reward_emote4 > -1" icon="/lu-res/textures/ui/achievements/general_social.png">Emote #{{mission.reward_emote4}}</lux-slot>
+      <lux-slot *ngIf="mission.reward_maxhealth > 0" icon="/lu-res/textures/ui/rewards/maxheart.png" [count]="mission.reward_maxhealth" luxTooltip="Life Point"></lux-slot>
+      <lux-slot *ngIf="mission.reward_maximagination > 0" icon="/lu-res/textures/ui/rewards/maximagination.png" [count]="mission.reward_maximagination" luxTooltip="Imagination Point"></lux-slot>
+      <lux-slot *ngIf="mission.reward_maxinventory > 0" icon="/lu-res/textures/ui/rewards/maxinventory.png" [count]="mission.reward_maxinventory" luxTooltip="Extra Backpack Space"></lux-slot>
+      <lux-slot *ngIf="mission.reward_maxmodel > 0" icon="/lu-res/textures/ui/rewards/maxmodel.png" [count]="mission.reward_maxmodel" luxTooltip="Extra Model Space"></lux-slot>
+      <lux-slot *ngIf="mission.reward_maxwidget > 0" icon="/lu-res/textures/ui/rewards/maxwidget.png" [count]="mission.reward_maxwidget" luxTooltip="Extra Behavior Space"></lux-slot>
+      <lux-slot *ngIf="mission.reward_maxwallet > 0" icon="/lu-res/textures/ui/rewards/maxwallet.png" [count]="mission.reward_maxwallet" luxTooltip="Extra Wallet Space"></lux-slot>
+      <lux-slot *ngIf="mission.reward_bankinventory > 0" icon="/lu-res/textures/ui/rewards/maxbank.png" [count]="mission.reward_bankinventory" luxTooltip="Extra Vault Space"></lux-slot>
+      <lux-slot *ngIf="mission.reward_emote > -1" icon="/lu-res/textures/ui/achievements/general_social.png" luxTooltip="Emote #{{mission.reward_emote}}"></lux-slot>
+      <lux-slot *ngIf="mission.reward_emote2 > -1" icon="/lu-res/textures/ui/achievements/general_social.png" luxTooltip="Emote #{{mission.reward_emote2}}"></lux-slot>
+      <lux-slot *ngIf="mission.reward_emote3 > -1" icon="/lu-res/textures/ui/achievements/general_social.png" luxTooltip="Emote #{{mission.reward_emote3}}"></lux-slot>
+      <lux-slot *ngIf="mission.reward_emote4 > -1" icon="/lu-res/textures/ui/achievements/general_social.png" luxTooltip="Emote #{{mission.reward_emote4}}"></lux-slot>
     </dd>
   </dl>
 


### PR DESCRIPTION
- Tooltips can now be text-only, by setting `luxTooltip="some string value"`, template based tooltips are also still supported
- Tooltip positioning is now calculated in absolute units from the top left of `<body>`
- Tooltips are now positioned centered above the element they're referencing, like text-only tooltips in LU. This is no longer in line with item tooltips in LU, which display on the side, but this shouldn't be too much of a problem.
- Tooltips now clamp to the window dimensions to avoid going out of bounds



- The tooltips for slots, added in the last PR, are no longer explicitly set by the slot component through content projection, but are now simply added via the `luxTooltip` attribute, like with any other element. I should have done it this way from the start but didn't know how tooltips worked back then.



- Tooltips are now always inserted as a direct child of `<body>` to avoid elements higher up in the tree messing with their positioning through `position: relative` somewhere.