### PR TITLE
Improve behavior tree readability

### DIFF
--- a/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
+++ b/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
@@ -366,9 +366,11 @@ export class BehaviorDetailAltComponent implements OnInit {
           borderRadius: 10
         },
         color: {
-          background: '#66f',
+          background: '#6161FF',
+          border: '#6161FF',
           highlight: {
-            background: '#4c4cff',
+            background: '#D14600',
+            border: '#D14600',
           },
         },
       },
@@ -389,8 +391,8 @@ export class BehaviorDetailAltComponent implements OnInit {
           to: true
         },
         color: {
-          color: '#9999ff',
-          highlight: '#4c4cff',
+          color: '#6161FF',
+          highlight: '#D14600',
         },
         arrowStrikethrough: false
       },

--- a/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
+++ b/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
@@ -358,12 +358,19 @@ export class BehaviorDetailAltComponent implements OnInit {
       nodes: {
         font: {
           size: 30,
-          face: 'nunito'
+          face: 'nunito',
+          color: '#fff',
         },
         shape: 'box',
         shapeProperties: {
           borderRadius: 10
-        }
+        },
+        color: {
+          background: '#66f',
+          highlight: {
+            background: '#4c4cff',
+          },
+        },
       },
       edges: {
         smooth: {
@@ -380,6 +387,10 @@ export class BehaviorDetailAltComponent implements OnInit {
         },
         arrows: {
           to: true
+        },
+        color: {
+          color: '#9999ff',
+          highlight: '#4c4cff',
         },
         arrowStrikethrough: false
       },

--- a/src/styles.css
+++ b/src/styles.css
@@ -238,7 +238,7 @@ td
   flex-wrap: wrap;
   list-style-type: none;
   padding: 0.5rem 2.5rem/* 0 2.5rem*/;
-  background-color: #66f;
+  background-color: #6161FF;
   border-top-left-radius: 3rem;
   border-top-right-radius: 3rem;
   margin: 0 2.5rem;


### PR DESCRIPTION
Currently, behavior trees have labels with the colour #343434 on a #111 background, this isn't a lot of contrast so it's a bit difficult to read, especially in certain light conditions.
In this PR I've changed the label text to white, and changed the node background colours to #66f, the colour used for the site menu background. When highlighted, nodes and the arrows between them get a more saturated version of this colour.

Before:
![old style](https://user-images.githubusercontent.com/11255568/126790509-211c4503-a0c8-4fe4-b6cc-831ab25f1e82.png)

After:
![new style](https://user-images.githubusercontent.com/11255568/126790535-1dd99a5e-c425-48c6-9e6c-19d377da3a9b.png)
