### PR TITLE
Fix object component links

### DIFF
--- a/src/app/gui/object/object.component.html
+++ b/src/app/gui/object/object.component.html
@@ -1,1 +1,1 @@
-<a href="/objects/{{id}}" [luxTooltip]="tooltip">{{title}}</a>
+<a routerLink="/objects/{{id}}" [luxTooltip]="tooltip">{{title}}</a>


### PR DESCRIPTION
Fixes MasterTemple's reported bug with link URLs, I forgot to use `routerLink` instead of `href`.