### PR TITLE
Add Mission component

### DIFF
--- a/src/app/gui/gui.module.ts
+++ b/src/app/gui/gui.module.ts
@@ -22,6 +22,8 @@ import { ObjectComponent } from './object/object.component';
 import { ObjectDirective } from './object/object.directive';
 import { MissiondisplayRewardComponent } from './missiondisplay-reward/missiondisplay-reward.component';
 import { BuffComponent } from './buff/buff.component';
+import { MissionComponent } from './mission/mission.component';
+import { MissionDirective } from './mission/mission.directive';
 
 @NgModule({
   declarations: [
@@ -40,6 +42,8 @@ import { BuffComponent } from './buff/buff.component';
     ObjectDirective,
     MissiondisplayRewardComponent,
     BuffComponent,
+    MissionComponent,
+    MissionDirective,
   ],
   imports: [
     CommonModule,
@@ -62,6 +66,8 @@ import { BuffComponent } from './buff/buff.component';
     ObjectComponent,
     ObjectDirective,
     MissiondisplayRewardComponent,
+    MissionComponent,
+    MissionDirective,
   ],
 })
 export class GuiModule { }

--- a/src/app/gui/mission/mission.component.css
+++ b/src/app/gui/mission/mission.component.css
@@ -1,0 +1,94 @@
+:host {
+    display: inline-block;
+    position: relative;
+    transition: transform 0.1s, filter 0.1s;
+}
+
+:host(:hover) {
+    transform: scale(105%);
+    filter: brightness(115%);
+}
+
+a {
+    text-decoration: none;
+}
+
+.status {
+    color: #fff;
+    left: 0;
+    right: 0;
+}
+
+.achievement {
+    position: relative;
+    width: 300px;
+}
+
+.achievement .slot {
+    background-image: url("/lu-res/ui/ingame/passport_ic.png");
+    background-size: 100% 100%;
+    padding-bottom: 17.1675%;
+    width: 100%;
+}
+
+.achievement .slot.complete {
+    background-image: url("/lu-res/ui/ingame/passport_i12.png");
+}
+
+.achievement .slot > * {
+    position: absolute;
+}
+
+.achievement .icon {
+    left: 5%;
+    top: 7%;
+    width: 15.625%;
+}
+
+.achievement .title {
+    align-items: center;
+    bottom: 0;
+    color: #fff;
+    display: flex;
+    font-weight: 600;
+    justify-content: center;
+    left: 0;
+    margin: auto;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    top: 5%;
+    width: 53.90%;
+}
+
+.mission {
+    width: 128px;
+}
+
+.mission .slot > * {
+    position: absolute;
+}
+
+.mission .slot {
+    background-image: url("/lu-res/ui/ingame/passport_i5a.png");
+    background-size: 100% 100%;
+    padding-bottom: 100%;
+    position: relative;
+}
+
+.mission .slot.complete {
+    background-image: url("/lu-res/ui/ingame/passport_i5d.png");
+}
+
+.mission .icon {
+    position: absolute;
+    left: 3.5%;
+    right: 9.5%;
+    top: 2.5%;
+}
+
+.mission .title {
+    color: #ccc;
+    font-weight: 600;
+    text-align: center;
+}

--- a/src/app/gui/mission/mission.component.html
+++ b/src/app/gui/mission/mission.component.html
@@ -1,0 +1,10 @@
+<a routerLink="/missions/{{id}}" [luxTooltip]="displayTooltip">
+  <div [class]="isMission ? 'mission' : 'achievement'" >
+    <div class="slot" [class.complete]="status == 4">
+      <app-icon class="icon" width="100%" [iconID]="iconID"></app-icon>
+      <span *ngIf="status != 2 && status != 4" class="status">status {{status}}</span>
+    </div>
+    <div class="title">{{title}}</div>
+  </div>
+</a>
+<ng-template #displayTooltip><span [innerHTML]="tooltip"></span><ng-template>

--- a/src/app/gui/mission/mission.component.spec.ts
+++ b/src/app/gui/mission/mission.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { MissionComponent } from "./mission.component";
+
+describe("MissionComponent", () => {
+  let component: MissionComponent;
+  let fixture: ComponentFixture<MissionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MissionComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MissionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/gui/mission/mission.component.ts
+++ b/src/app/gui/mission/mission.component.ts
@@ -1,0 +1,17 @@
+import { Component, HostBinding, Input } from "@angular/core";
+
+@Component({
+  selector: "lux-mission",
+  templateUrl: "./mission.component.html",
+  styleUrls: ["./mission.component.css"]
+})
+export class MissionComponent {
+  @Input() id: number;
+  @Input() isMission: boolean = true;
+  @Input() iconID: number;
+  @Input() title: string;
+  @Input() tooltip: string;
+  @HostBinding("style.order")
+  @Input() sortOrder: number = 0;
+  @Input() status: number = 4;
+}

--- a/src/app/gui/mission/mission.directive.spec.ts
+++ b/src/app/gui/mission/mission.directive.spec.ts
@@ -1,0 +1,8 @@
+import { MissionDirective } from "./mission.directive";
+
+describe("TooltipDirective", () => {
+  it("should create an instance", () => {
+    //const directive = new MissionDirective();
+    //expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/gui/mission/mission.directive.ts
+++ b/src/app/gui/mission/mission.directive.ts
@@ -1,0 +1,41 @@
+import { Directive, Input } from "@angular/core";
+import { MissionComponent } from "./mission.component";
+import { LuJsonService, LuLocaleService } from "../../services";
+import { DB_Missions } from "../../cdclient";
+
+@Directive({
+  selector: "lux-mission[luxFetch]"
+})
+export class MissionDirective {
+
+  @Input("luxFetch") set id(id: number) {
+    this.missionComponent.id = id;
+    this.missionComponent.title = `#${id}`;
+    this.luJson.getMission(id).subscribe(this.onMission);
+    this.luLocale.getLocaleEntry("Missions", id).subscribe(x => { if (x) { this.missionComponent.title = x.name; }});
+    this.luLocale.getLocaleEntry("MissionText", id).subscribe(this.onMissionText);
+  }
+
+  constructor(private luJson: LuJsonService, private luLocale: LuLocaleService, private missionComponent: MissionComponent) {
+  }
+
+  onMission = (mission: DB_Missions) => {
+    this.missionComponent.isMission = mission.isMission;
+    this.missionComponent.sortOrder = -mission.isMission * 10000 + mission.UISortOrder;
+    if (mission.isMission) {
+      this.luJson.getMissionTasks(this.missionComponent.id).subscribe(x => this.missionComponent.iconID = x.tasks[0].largeTaskIconID);
+    } else {
+      this.missionComponent.iconID = mission.missionIconID;
+    }
+  }
+
+  onMissionText = (missionText: any) => {
+    if (missionText) {
+      if (missionText.in_progress) {
+        this.missionComponent.tooltip = missionText.in_progress;
+      } else if (missionText.description) {
+        this.missionComponent.tooltip = missionText.description;
+      }
+    }
+  }
+}

--- a/src/app/missions/by-subtype/by-subtype.component.css
+++ b/src/app/missions/by-subtype/by-subtype.component.css
@@ -1,0 +1,12 @@
+.mission-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.mission-separator {
+    break-before: always;
+    break-after: always;
+    height: 2rem;
+    order: 0;
+}

--- a/src/app/missions/by-subtype/by-subtype.component.html
+++ b/src/app/missions/by-subtype/by-subtype.component.html
@@ -7,11 +7,7 @@
 <app-group-icon [name]="defined_type"></app-group-icon>
 <h2>Missions <small>{{defined_type}} - {{defined_subtype}}</small></h2>
 
-<table>
-  <tr *ngFor="let mission_id of mission_ids">
-    <td>{{mission_id}}</td>
-    <td><a [routerLink]="['/missions/', mission_id]">
-      {{ mission_names && mission_names[mission_id] ? mission_names[mission_id].name : "[Unnamed]"}}
-    </a></td>
-  </tr>
-</table>
+<div class="mission-list">
+  <div class="mission-separator"></div>
+  <lux-mission [luxFetch]="mission_id" *ngFor="let mission_id of mission_ids"></lux-mission>
+</div>

--- a/src/app/missions/by-type/by-type.component.css
+++ b/src/app/missions/by-type/by-type.component.css
@@ -1,0 +1,12 @@
+.mission-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.mission-separator {
+    break-before: always;
+    break-after: always;
+    height: 2rem;
+    order: 0;
+}

--- a/src/app/missions/by-type/by-type.component.html
+++ b/src/app/missions/by-type/by-type.component.html
@@ -20,12 +20,8 @@
 <section *ngIf="mission_ids && mission_ids.length > 0">
   <h3>Missions</h3>
 
-  <table>
-    <tr *ngFor="let mission_id of mission_ids">
-      <td>{{mission_id}}</td>
-      <td><a [routerLink]="['/missions/', mission_id]">
-        {{ mission_names && mission_names[mission_id] ? mission_names[mission_id].name : "[Unnamed]"}}
-      </a></td>
-    </tr>
-  </table>
+  <div class="mission-list">
+    <div class="mission-separator"></div>
+    <lux-mission [luxFetch]="mission_id" *ngFor="let mission_id of mission_ids"></lux-mission>
+  </div>
 </section>

--- a/src/app/missions/detail/detail.component.css
+++ b/src/app/missions/detail/detail.component.css
@@ -23,6 +23,10 @@
     background-color: unset;
 }
 
+#mission-display, #mission-prereqs {
+    text-align: center;
+}
+
 .currency-rewards {
     display: flex;
     flex-wrap: wrap;

--- a/src/app/missions/detail/detail.component.css
+++ b/src/app/missions/detail/detail.component.css
@@ -23,8 +23,9 @@
     background-color: unset;
 }
 
-#mission-display, #mission-prereqs {
-    text-align: center;
+#mission-prereqs {
+    display: flex;
+    justify-content: center;
 }
 
 .currency-rewards {

--- a/src/app/missions/detail/detail.component.html
+++ b/src/app/missions/detail/detail.component.html
@@ -65,10 +65,6 @@
   </table>
 </section>
 
-<section id="mission-display">
-  <lux-mission [luxFetch]="id" [status]="2"></lux-mission>
-</section>
-
 <section *ngIf="mission && mission.prereqMissionID">
   <h3>Prerequisites</h3>
   <div id="mission-prereqs">

--- a/src/app/missions/detail/detail.component.html
+++ b/src/app/missions/detail/detail.component.html
@@ -65,11 +65,15 @@
   </table>
 </section>
 
-<app-icon class="mission-icon" [iconID]="mission.missionIconID" *ngIf="mission && mission.missionIconID"></app-icon>
+<section id="mission-display">
+  <lux-mission [luxFetch]="id" [status]="2"></lux-mission>
+</section>
 
 <section *ngIf="mission && mission.prereqMissionID">
   <h3>Prerequisites</h3>
-  <mission-ref-list [ref]="mission.prereqMissionID | condast"></mission-ref-list>
+  <div id="mission-prereqs">
+    <mission-ref-list [ref]="mission.prereqMissionID | condast"></mission-ref-list>
+  </div>
 </section>
 
 <section id="flags" *ngIf="mission">

--- a/src/app/missions/ref-list/ref-list.component.css
+++ b/src/app/missions/ref-list/ref-list.component.css
@@ -1,0 +1,31 @@
+:host {
+    display: inline-block;
+}
+
+p {
+    margin: 0;
+    text-align: center;
+}
+
+ul {
+    border-radius: 10px;
+    border-top: 1px solid #999;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin: 0;
+    padding-top: 1rem;
+    padding-left: 0;
+}
+
+li {
+    display: block;
+    padding: 0 2px;
+}
+
+@media (max-width: 500px) {
+    ul {
+        border-bottom: 1px solid #999;
+        padding-bottom: 1rem;
+    }
+}

--- a/src/app/missions/ref-list/ref-list.component.html
+++ b/src/app/missions/ref-list/ref-list.component.html
@@ -1,15 +1,22 @@
-<span *ngIf="ref.type == 'lit'">Mission
-  <a routerLink="/missions/{{ref.value}}">{{ref.value}}</a>
+<span *ngIf="ref.type == 'lit'">
+  <lux-mission [luxFetch]="ref.value"></lux-mission>
 </span>
-<dl *ngIf="ref.type == '|'">
-  <dt>Any of</dt>
-  <dd *ngFor="let item of ref.value">
-    <mission-ref-list [ref]="item"></mission-ref-list>
-  </dd>
-</dl>
-<dl *ngIf="ref.type == ','">
-  <dt>All of</dt>
-  <dd *ngFor="let item of ref.value">
-    <mission-ref-list [ref]="item"></mission-ref-list>
-  </dd>
-</dl>
+<span *ngIf="ref.type == ':'">
+  <lux-mission [luxFetch]="ref.value.id" [status]="ref.value.status"></lux-mission>
+</span>
+<div *ngIf="ref.type == '|'">
+  <p>Any of</p>
+  <ul>
+    <li *ngFor="let item of ref.value">
+      <mission-ref-list [ref]="item"></mission-ref-list>
+    </li>
+  </ul>
+</div>
+<div *ngIf="ref.type == ','">
+  <p>All of</p>
+  <ul>
+    <li *ngFor="let item of ref.value">
+      <mission-ref-list [ref]="item"></mission-ref-list>
+    </li>
+  </ul>
+</div>

--- a/src/app/util/icon/icon.component.ts
+++ b/src/app/util/icon/icon.component.ts
@@ -9,25 +9,23 @@ import { DB_Icons } from '../../cdclient';
   styleUrls: ['./icon.component.css']
 })
 export class IconComponent implements OnInit {
-
-  @Input() iconID: number;
+  private _iconID: number;
   @Input() width: string = '64px';
   @Input() caption: boolean = true;
   icon: DB_Icons;
+
+  get iconID(): number { return this._iconID; }
+
+  @Input() set iconID(value: number) {
+    this._iconID = value;
+    if (this.iconID != undefined) {
+      this.luJsonService.getIcon(this.iconID).subscribe(icon => this.icon = icon);
+    }
+  }
 
   constructor(private luJsonService: LuJsonService) {
   }
 
   ngOnInit() {
-  	this.getIcon();
   }
-
-  getIcon(): void {
-  	if (this.iconID != undefined)
-  	{
-  	  this.luJsonService.getIcon(this.iconID)
-        .subscribe(icon => this.icon = icon);
-  	}
-  }
-
 }

--- a/src/app/util/pipes/conditions.pipe.ts
+++ b/src/app/util/pipes/conditions.pipe.ts
@@ -37,7 +37,7 @@ function tokenizePrereqString(prereq: string): Array<string>
       }
       res.push(['&', ';'].includes(c) ? ',' : c);
       buf = "";
-    } else if (['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'].includes(c)) {
+    } else if (['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', ':'].includes(c)) {
       buf += c;
     } else {
       throw SyntaxError("Unexpected character '" + c + "' in '" + prereq + "'");
@@ -73,14 +73,23 @@ function checkPrereqNesting(tokens: Array<String>): any {
 }
 
 function parseMissionStringElem(e: any): any {
-  return Array.isArray(e) ? parseMissionString(e) : {type: "lit", value: Number(e)};
+  if (Array.isArray(e)) {
+    return parseMissionString(e);
+  }
+
+  const parts = e.split(":");
+  if (parts.length == 1) {
+    return {type: "lit", value: Number(parts[0])};
+  } else {
+    return {type: ":", value: {id: Number(parts[0]), status: Number(parts[1])}};
+  }
 }
 
 function parseMissionString(ast: any): any {
   if (ast.length == 0) {
     throw SyntaxError("Mission AST may not be empty");
   } else if (ast.length == 1) {
-    return {type: "lit", value: Number(ast[0])};
+    return parseMissionStringElem(ast[0]);
   } else if (ast.length % 2 == 0) {
     throw SyntaxError("Mission AST must have uneven number of elements");
   } else {


### PR DESCRIPTION
This adds the mission component gui element, to be used when referring to a mission. It shows the mission name and icon, as well as a description tooltip and a different background in the cases where a prerequisite specifically refers to a mission in a non-complete state. The style is very close to the ingame passport, and changes appropriately if the mission is an achievement.

This component is then used in the mission detail view, the mission reflist component used for mission prereqs, as well as the mission type and subtype listings.

In addition, this PR also fixes a bug with the app icon component not updating when its input changed, and fixes #41 by adding support for mission states to mission prereq parsing.

Right now, this does 4 requests per mission, which causes the mission listings to have quite a large number of requests, but since the component is split into a component and a directive to populate it, it would be very straightforward to change the system to populate the component based on a precompiled listing json.

Since this visually distinguishes and groups achievements and missions in the listing view, this also fixes #34.

Screenshots:
### Mission List
![Mission List](https://cdn.discordapp.com/attachments/348902070109077525/851034491149221888/unknown.png)
### Mission detail & prereqs, non-complete state prereq
![Mission detail & prereqs](https://cdn.discordapp.com/attachments/348902070109077525/847523409209458759/unknown.png)
### Mission prereqs, complex prereq
![](https://cdn.discordapp.com/attachments/348902070109077525/847515797911109702/unknown.png)