### PR TITLE
Behavior graph quality of life improvements

### DIFF
--- a/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.css
+++ b/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.css
@@ -1,8 +1,27 @@
-#mynetwork
-{
-	color: #000;
+#mynetwork {
+    color: #000;
+    background-color: transparent;
+    height: 80vh;
 }
 
 .skill-link + .skill-link::before {
-	content: ", ";
+    content: ", ";
+}
+
+@media(min-width: 800px) {
+    #behavior-pane {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    #behavior-inspector {
+        flex: 1;
+        height: 80vh;
+        min-width: 300px;
+        overflow-y: auto;
+    }
+
+    #mynetwork {
+        flex: 10;
+    }
 }

--- a/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.html
+++ b/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.html
@@ -6,33 +6,37 @@
   </p>
   <hr>
 </section>
-<div id="mynetwork"></div>
-<table *ngIf="selectedBehavior">
-  <tr>
-    <th>Key</th>
-    <th>Value</th>
-  </tr>
-  <tr>
-    <td>behaviorID</td>
-    <td>{{selectedBehaviorID}}</td>
-  </tr>
-  <tr>
-    <td>templateID</td>
-    <td>{{selectedBehavior.templateID}}</td>
-  </tr>
-  <tr>
-    <td>effectID</td>
-    <td>{{selectedBehavior.effectID}}</td>
-  </tr>
-  <tr>
-    <td>effectHandle</td>
-    <td>{{selectedBehavior.effectHandle}}</td>
-  </tr>
-  <tr *ngFor="let entry of selectedBehavior.parameters | keys">
-    <td>{{entry.key}}</td>
-    <td>{{entry.value}}</td>
-  </tr>
-</table>
+<div id="behavior-pane">
+  <div id="mynetwork"></div>
+  <div id="behavior-inspector">
+    <table *ngIf="selectedBehavior">
+      <tr>
+        <th>Key</th>
+        <th>Value</th>
+      </tr>
+      <tr>
+        <td>behaviorID</td>
+        <td>{{selectedBehavior.behaviorID}}</td>
+      </tr>
+      <tr>
+        <td>templateID</td>
+        <td>{{selectedBehavior.templateID}}</td>
+      </tr>
+      <tr>
+        <td>effectID</td>
+        <td>{{selectedBehavior.effectID}}</td>
+      </tr>
+      <tr>
+        <td>effectHandle</td>
+        <td>{{selectedBehavior.effectHandle}}</td>
+      </tr>
+      <tr *ngFor="let entry of selectedBehavior.parameters | keys">
+        <td>{{entry.key}}</td>
+        <td>{{entry.value}}</td>
+      </tr>
+    </table>
+  </div>
+</div>
 <div *ngIf="errors.length > 0">
   Failed to fetch data for behavior nodes:
   <ul>

--- a/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
+++ b/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { DB_Behavior } from '../../../defs/cdclient';
 import { Rev_Behavior } from '../../../defs/api';
@@ -16,7 +16,6 @@ declare var vis: any;
 export class BehaviorDetailAltComponent implements OnInit {
   id: number;
 
-  selectedBehaviorID: number;
   nodes: any[] = [];
   edges: any[] = [];
   behaviors: any = {};
@@ -32,6 +31,7 @@ export class BehaviorDetailAltComponent implements OnInit {
   errors: number[] = [];
 
   constructor(private route: ActivatedRoute,
+    private router: Router,
     private luCoreData: LuCoreDataService) {
   }
 
@@ -316,6 +316,8 @@ export class BehaviorDetailAltComponent implements OnInit {
       this.nodes.push({ id: this.id, label: String(this.id), level: 0 });
       this.process(this.id, 0);
       this.redraw();
+      this.selectedBehavior = this.behaviors[this.route.snapshot.paramMap.get('selected')];
+      this.network.selectNodes([this.selectedBehavior.behaviorID]);
     });
   }
 
@@ -325,15 +327,6 @@ export class BehaviorDetailAltComponent implements OnInit {
       this.network = undefined;
     }
 
-    let i = 0;
-    let m = 1;
-    let d = 1;
-    while (d > 0) {
-      d = this.nodes.filter(node => node.level === i).length;
-      m = Math.max(d, m);
-      i++;
-    }
-
     var data = {
       nodes: this.nodes,
       edges: this.edges
@@ -341,7 +334,7 @@ export class BehaviorDetailAltComponent implements OnInit {
 
     var options = {
       width: '100%',
-      height: m * (900 / i) + 'px',
+      height: '100%',
       nodes: {
         font: {
           size: 30,
@@ -406,11 +399,10 @@ export class BehaviorDetailAltComponent implements OnInit {
 
   select(params: any): void {
     if (params.nodes.length > 0) {
+      this.router.navigate(['..', params.nodes[0]], { relativeTo: this.route });
       this.selectedBehavior = this.behaviors[params.nodes[0]];
-      this.selectedBehaviorID = params.nodes[0];
     } else {
       this.selectedBehavior = undefined;
-      this.selectedBehaviorID = undefined;
     }
   }
 

--- a/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
+++ b/src/app/skills/behavior-detail-alt/behavior-detail-alt.component.ts
@@ -374,6 +374,7 @@ export class BehaviorDetailAltComponent implements OnInit {
           color: '#6161FF',
           highlight: '#D14600',
         },
+        selectionWidth: 10,
         arrowStrikethrough: false
       },
       layout: {
@@ -394,16 +395,40 @@ export class BehaviorDetailAltComponent implements OnInit {
       }
     };
     this.network = new vis.Network(this.container, data, options);
-    this.network.on('select', params => this.select(params));
+    this.network.on('click', params => {
+      this.select(params.nodes[0], "to");
+    });
+    this.network.on('oncontext', params => {
+      params.event.preventDefault();
+      const nodeId = this.network.getNodeAt(params.pointer.DOM);
+      this.select(nodeId, "from");
+    });
   }
 
-  select(params: any): void {
-    if (params.nodes.length > 0) {
-      this.router.navigate(['..', params.nodes[0]], { relativeTo: this.route });
-      this.selectedBehavior = this.behaviors[params.nodes[0]];
-    } else {
+  select(nodeId, dir): void {
+    if (!nodeId) {
       this.selectedBehavior = undefined;
+      return;
+    }
+    this.router.navigate(['..', nodeId], { relativeTo: this.route });
+    this.selectedBehavior = this.behaviors[nodeId];
+    let nodes = [];
+    let edges = [];
+    this.getConnected(this.selectedBehavior.behaviorID, nodes, edges, dir);
+    this.network.setSelection({ nodes: nodes, edges: edges }, { highlightEdges: false });
+  }
+
+  getConnected(nodeId, nodes, edges, dir) {
+    nodes.push(nodeId);
+    const node = this.network.body.nodes[nodeId];
+    for (const edge of node.edges) {
+      if (dir === "from" && edge.toId == node.id) {
+        edges.push(edge.id);
+        this.getConnected(edge.fromId, nodes, edges, dir);
+      } else if (dir === "to" && edge.fromId == node.id) {
+        edges.push(edge.id);
+        this.getConnected(edge.toId, nodes, edges, dir);
+      }
     }
   }
-
 }

--- a/src/app/skills/skills-routing.module.ts
+++ b/src/app/skills/skills-routing.module.ts
@@ -6,7 +6,8 @@ import { SkillComponent } from './skill/skill.component';
 import { SkillsComponent } from './skills.component';
 
 const skillsRoutes: Routes = [
-  { path: 'behaviors/:id', component: BehaviorDetailAltComponent, data: { title: params => `Behavior #${params['id']}` } },
+  { path: 'behaviors/:id', redirectTo: 'behaviors/:id/:id', pathMatch: 'full' },
+  { path: 'behaviors/:id/:selected', component: BehaviorDetailAltComponent, data: { title: params => `Behavior #${params['id']}` } },
   { path: ':id', component: SkillComponent, data: { title: params => `Skill #${params['id']}` } },
   { path: '', component: SkillsComponent, data: { title: "Skills" } }
 ];


### PR DESCRIPTION
A couple changes to make working with the behavior graph easier, especially for large graphs:

- The key/value table will now appear on the side on large screen, so you don't have to constantly scroll up and down when comparing nodes.
- The selected node now appears in the URL and can be linked. Links with a specific node highlighted will restore the highlight when loaded.
- Clicking on a node will now highlight all descendant nodes instead of just the clicked node. This makes it much easier to simulate execution of a behavior graph step-by-step without losing track, and allows you to see all possible outcomes of a node.
- Similarly, right-clicking on a node will highlight all the ancestor nodes instead, so you can easily see which path(s) led there.